### PR TITLE
Ignore UnicodeDecodeError/ValueError when "initializing" Japanese model

### DIFF
--- a/src/fonduer/parser/spacy_parser.py
+++ b/src/fonduer/parser/spacy_parser.py
@@ -130,11 +130,15 @@ class Spacy(object):
             language_module = importlib.import_module("spacy.lang.{}".format(self.lang))
             language_method = getattr(language_module, self.alpha_languages[self.lang])
             model = language_method()
-            """ TODO: an UnicodeDecodeError happens about once every two when lang='ja'.
+            """ TODO: Depending on OS (Linux/macOS) and on the sentence to be parsed,
+            UnicodeDecodeError or ValueError happens at the first use when lang='ja'.
             As a workaround, the model parses some sentence before actually being used.
             """
             if self.lang == "ja":
-                model("テスト")
+                try:
+                    model("初期化")
+                except (UnicodeDecodeError, ValueError):
+                    pass
         self.model = model
 
     def sentence_list_separator_function(self, all_sentence_objs):


### PR DESCRIPTION
I tested the last commit on macOS and realized that the last commit produces an UnicodeDecodeError/ValueError on Ubuntu.
Japanese is alpha-supported after all.
I ran the unit test on both OS (Ubuntu and macOS) 10 times each, and confirmed that the test passed.

These are the detailed information.
Ubuntu (bionic)
platform linux -- Python 3.6.5, pytest-3.7.2, py-1.5.4, pluggy-0.7.1
mecab-python3            0.7
mecab:
  Installed: 0.996-5
libmecab-dev:
  Installed: 0.996-5
mecab-ipadic-utf8:
  Installed: 2.7.0-20070801+main-1

macOS (10.12.6)
platform darwin -- Python 3.7.0, pytest-3.7.3, py-1.6.0, pluggy-0.7.1
mecab-python3            0.7
mecab: stable 0.996 (bottled)
mecab-ipadic: stable 2.7.0-20070801 (bottled)